### PR TITLE
Make quickstarts compatible with monday code

### DIFF
--- a/apps/quickstart-integrations/README.md
+++ b/apps/quickstart-integrations/README.md
@@ -59,7 +59,7 @@ In short, integrations run off of triggers that invoke certain actions. These tr
 2. Run the server using the monday tunnel:
 
 ```
-$ npm start
+$ npm run dev
 ```
 
  ### Part Five: Using the custom integration recipe

--- a/apps/quickstart-integrations/package.json
+++ b/apps/quickstart-integrations/package.json
@@ -3,7 +3,8 @@
   "version": "0.0.1",
   "license": "MIT",
   "scripts": {
-    "start": "npm run stop && concurrently \"npm run server\" \"npm run expose\"",
+    "start" : "node ./src/app.js",
+    "dev": "npm run stop && concurrently \"npm run server\" \"npm run expose\"",
     "server": "nodemon ./src/app.js",
     "expose": "mapps tunnel:create -p 8302",
     "stop": "kill-port 8302"


### PR DESCRIPTION
This task is to make the main quickstart guides compatible with monday code, and mark the ones that are not. 

@shaikatzz - follow up from Slack!