### PR TITLE
update word-cloud to use the latest api structure

### DIFF
--- a/apps/word-cloud/src/App.js
+++ b/apps/word-cloud/src/App.js
@@ -48,7 +48,23 @@ class App extends React.Component {
 
     const boardIds = context.boardIds || [context.boardId];
     monday
-      .api(`query { boards(ids:[${boardIds}]) { id, items { id, name, column_values { id, text } } }}`)
+      .api(`
+        query {
+          boards(ids: [${boardIds}]) {
+            id
+            items_page {
+              items {
+                id
+                name
+                column_values {
+                  id
+                  text
+                }
+              }
+            }
+          }
+        }
+      `)
       .then((res) => {
         const noBoardsReturned = res.data.boards.length === 0;
         if (noBoardsReturned) {
@@ -56,7 +72,7 @@ class App extends React.Component {
           this.setState({ hasNoBoards : true })
         } else {
           this.setState({ boards: res.data.boards, hasNoBoards: false,  hasApiError: false }, () => {
-            console.log(res.data.boards[0].items.slice(0, 10).map((item) => item.id));
+            console.log(res.data.boards[0].items_page.items.slice(0, 10).map((item) => item.id));
             this.generateWords();
           });
         }
@@ -98,7 +114,7 @@ class App extends React.Component {
   getText = () => {
     const { boards, settings, itemIds } = this.state;
     const result = boards.map((board) => {
-      return board.items
+      return board.items_page.items
         .filter((item) => !itemIds || itemIds[item.id])
         .map((item) => {
           let columnIds, values;


### PR DESCRIPTION
I followed along the instructions at https://github.com/mondaycom/welcome-apps/tree/master/apps/word-cloud to see how this app works. It didn't work.

The console output implies that a graphql request is asking for some field that doesn't exist.
Old code: boards -> items (no such field under 'boards')
New code: boards -> items_page -> items. Doc: https://developer.monday.com/api-reference/reference/boards#fields

So I read the documentation and updated the code to fit the latest API version. The app works now.