### PR TITLE
Github integration - added clarification

### DIFF
--- a/apps/github-monday-code/src/routes/trigger.js
+++ b/apps/github-monday-code/src/routes/trigger.js
@@ -14,7 +14,10 @@ router.post('/monday/unsubscribe', authenticationMiddleware, triggerController.u
  * The endpoint to receive webhook events from Github. It is called when a new issue is created.
  * Each instance of the trigger block will use a unique subscription ID.
  * For implementation, see '/apps/github-node/src/services/github-service.js'
+ * 
+ * NOTE: You should authenticate incoming requests in a production app. 
+ * For an example, see `/apps/github-node/src/middlewares/authentication.js`
  */
-router.post('/integration/integration-events/:subscriptionId', triggerController.triggerEventsHandler);
+router.post('/integration/integration-events/:subscriptionId', triggerController.triggerEventsHandler); 
 
 export default router;


### PR DESCRIPTION
Clarified that you should authenticate incoming requests yourself. 

From issue 134 - https://github.com/mondaycom/welcome-apps/issues/134