### PR TITLE
docs: update signing secret instructions

### DIFF
--- a/apps/quickstart-fullstack-react-node/README.md
+++ b/apps/quickstart-fullstack-react-node/README.md
@@ -20,8 +20,7 @@ npm install
 ## Run the project
 
 1. Add your MONDAY_SIGNING_SECRET to .env file
-   <br> \*\* To get your MONDAY_SIGNING_SECRET go to monday.com, open Developers section, open your app and find the Signing Secret in "Basic Information" section
-   <br> ![Screenshot](https://dapulse-res.cloudinary.com/image/upload/f_auto,q_auto/remote_mondaycom_static/uploads/VladMystetskyi/4db4f03e-67a5-482d-893e-033db67ee09b_monday-Apps2020-05-1901-31-26.png)
+   <br> \*\* To get your MONDAY_SIGNING_SECRET, go to monday.com, open the Developers section, open your app, and copy the Client Secret Value.
 2. Build the client code and run the server with ngrok tunnel with the command:
 
 ```bash

--- a/apps/quickstart-integrations-ts/README.md
+++ b/apps/quickstart-integrations-ts/README.md
@@ -55,8 +55,7 @@ In short, integrations run off of triggers that invoke certain actions. These tr
 ## Part 4: Run the project
 
 1. Add your MONDAY_SIGNING_SECRET to .env file
-   <br> \*\* To get your MONDAY_SIGNING_SECRET go to monday.com, open Developers section, open your app and find the Signing Secret in "Basic Information" section
-   <br> ![Screenshot](https://dapulse-res.cloudinary.com/image/upload/f_auto,q_auto/remote_mondaycom_static/uploads/VladMystetskyi/4db4f03e-67a5-482d-893e-033db67ee09b_monday-Apps2020-05-1901-31-26.png)
+   <br> \*\* To get your MONDAY_SIGNING_SECRET, go to monday.com, open the Developers section, open your app, and copy the Client Secret Value.
 2. Run the server with ngrok tunnel with the command:
 
 ```


### PR DESCRIPTION
Summary:
- Update the quickstart fullstack app README to point `MONDAY_SIGNING_SECRET` users at the Client Secret Value.
- Apply the same wording to the TypeScript quickstart integration README, which had the same stale instruction.
- Remove the old screenshot from both spots so the docs no longer point readers at the outdated Basic Information UI.

Verification:
- `rg -n "find the Signing Secret|Basic Information|Client Secret Value|MONDAY_SIGNING_SECRET" apps/quickstart-fullstack-react-node/README.md apps/quickstart-integrations-ts/README.md`
- `git diff --check`

Fixes #132.

This was implemented with Codex assistance, with the final diff manually reviewed and kept to documentation only.